### PR TITLE
Add Mongotron

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing. F
  - [MongoChef](http://3t.io/mongochef) - Cross-platform MongoDB manager, stable and powerful
  - [MongoBooster](http://www.mongobooster.com) - Feature-rich but easy-to-use cross-platform MongoDB manager
  - [MongoHub](https://github.com/jeromelebel/MongoHub-Mac) - Mac native client
+ - [Mongotron](http://mongotron.io/) - Cross-platform, open-source MongoDB client built with Electron
  - [Robomongo](https://github.com/paralect/robomongo) - Native and cross-platform MongoDB manager
 
 ### Monitoring


### PR DESCRIPTION
Adds Mongotron to the README.md file. 

Was just writing an article, checked to see if there was an awesome list for MongoDB, and noticed that Mongotron wasn't on the desktop clients list. Wanted to add ❤️