### PR TITLE
add mongoplayground.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing. F
  - [HumongouS.io](https://www.humongous.io) - Easy online GUI and data-visualization dashboards
  - [mongo-express](https://github.com/mongo-express/mongo-express) - Web-based admin interface written with Node.js, Express and Bootstrap3
  - [mongoadmin](https://github.com/thomasst/mongoadmin) - Admin interface for MongoDB built using Django and Bootstrap
+ - [mongoplayground](https://mongoplayground.net) - An online playground for MongoDB
  - [mongri](https://github.com/dongri/mongri) - Web-based user interface for MongoDB (written in JavaScript)
  - [Rockmongo](https://github.com/iwind/rockmongo) - PHPMyAdmin for MongoDB, sort of
 


### PR DESCRIPTION
Hi,
    
I recently created an online playground for MongoDB. You can see it live here: [mongoplayground.net](https://mongoplayground.net). Source code is available [here](https://github.com/feliixx/mongoplayground).
If you find this project interesting, please add it to the list!
Thanks for maintaining this,
    
feliixx