### PR TITLE
docs(lib): adds CASL mongoose

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing. F
  - [MERN (mern-starter)](https://github.com/Hashnode/mern-starter) - Full-Stack based on MongoDB, Express, React and Node.js
  - [Meteor](https://github.com/meteor/meteor) - Real-time/reactive client-server framework, based on MongoDB, with lots of features
  - [Mongoose](https://github.com/Automattic/mongoose) - Node.js asynchronous ODM
+ - [CASL Mongoose](https://github.com/stalniy/casl/tree/master/packages/casl-mongoose) - Permissions management library integrated with Mongoose
  - [mongration](https://github.com/awapps/mongration) - Node.js migration framework
  - [Moonridge](https://github.com/capaj/Moonridge) - Framework with live querying on top of Mongoose and socket.io
  - [node-mongodb-native](https://github.com/mongodb/node-mongodb-native) - Official Node.js driver


### PR DESCRIPTION
I added a library for authorization in Nodejs with MongoDB. The library is called CASL - https://github.com/stalniy/casl. There are also a lot of interesting stuff in  documentation - https://stalniy.github.io/casl/ and [related articles on Medium](https://medium.com/@sergiy.stotskiy/latest). 

The library has been around for almost a year, I used it on several projects and believe it's a very good addition to this list.