### PR TITLE
Add Mongo Seeding to Development tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing. F
  - [Robo 3T](https://github.com/Studio3T/robomongo) - Free, native and cross-platform MongoDB manager (formerly Robomongo)
  - [Studio 3T](https://studio3t.com/) - Cross-platform MongoDB manager, stable and powerful (formerly MongoChef)
 
+### Development
+ - [Mongo Seeding](https://github.com/pkosiec/mongo-seeding) - Node.js library, CLI and Docker image for populating MongoDB database using JS and JSON files
+
 ### Monitoring
  - [check_mongodb](https://github.com/dalenys/check_mongodb) - Nagios plugin (in Bash)
  - [Datadog](https://www.datadoghq.com/blog/monitor-mongodb-performance-with-datadog/) - SaaS-based MongoDB monitoring


### PR DESCRIPTION
Hello,
I'm the author of Mongo Seeding - ultimate tool for populating MongoDB database. This is a project that I'm developing from a while ago (11.2017), but it's not popular - I haven't promoted it yet. There are some alternatives, but they are bare-bones - that's why I've started my own project.

I wasn't sure in which section I should put it - because this is not only Node.js library, but also CLI and Docker image.

Let me know what you think!

Best,
Pawel