### PR TITLE
Add tutorial: Deploy a Highly-Available MongoDB Replica Set on AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing. F
 ### Tutorials
  - [Create a TV Show Tracker Using AngularJS, Node.js, and MongoDB](http://sahatyalkabov.com/create-a-tv-show-tracker-using-angularjs-nodejs-and-mongodb/) - Build a REST API using Mongoose to create and retrieve data
  - [Kubernetes examples](https://github.com/kubernetes/examples/tree/master/staging/nodesjs-mongodb) - Deployment tutorial of a basic Node.js and MongoDB web stack on Kubernetes
+ - [Deploy a Highly-Available MongoDB Replica Set on AWS](https://eladnava.com/deploy-a-highly-available-mongodb-replica-set-on-aws/) - Extremely detailed guide on how to deploy a MongoDB replica set on Amazon Web Services
 
 ### More
  - [MongoDB source code](https://github.com/mongodb/mongo)


### PR DESCRIPTION
Please consider adding this (although it is a bit outdated, it's still a great guide, just the MongoDB version number needs to be changed but the tutorial is still valid). 👍 