### PR TITLE
Mongodb rust driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing. F
  - [Mongoid](https://github.com/mongodb/mongoid) - ODM framework
 
 ### Rust
- - [mongodb-rust](https://github.com/mongodb/mongo-rust-driver) - Official Rust driver
+ - [mongodb-rust-driver](https://github.com/mongodb/mongo-rust-driver) - Official Rust driver
 
 ### Scala
  - [mongo-scala-driver](https://github.com/mongodb/mongo-scala-driver) - Official Scala driver

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing. F
  - [Mongoid](https://github.com/mongodb/mongoid) - ODM framework
 
 ### Rust
- - [mongo-rust-driver-prototype](https://github.com/mongodb-labs/mongo-rust-driver-prototype) - Prototype driver for Rust 1.x and MongoDB 3.0.x
+ - [mongodb-rust](https://github.com/mongodb/mongo-rust-driver) - Official Rust driver
 
 ### Scala
  - [mongo-scala-driver](https://github.com/mongodb/mongo-scala-driver) - Official Scala driver


### PR DESCRIPTION
The official MongoDB rust driver reached 1.0 last year, and is hosted in a different repo to the prototype.