### PR TITLE
Add Compass to Desktop section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Services:
  - [puppet-mongodb](https://github.com/voxpupuli/puppet-mongodb) - Puppet module (formerly puppetlabs-mongodb)
 
 ### Desktop
+ - [Compass](https://www.mongodb.com/products/compass) - Free Cross-platform GUI from MongoDB
  - [DataGrip](https://www.jetbrains.com/datagrip/) - Cross-platform JetBrains' IDE
  - [dbKoda](https://www.dbkoda.com) - Cross-platform and open-source IDE
  - [MongoHub](https://github.com/jeromelebel/MongoHub-Mac) - Mac native client


### PR DESCRIPTION
Added [Compass](https://www.mongodb.com/products/compass).

I wasn't originally going to add the word "free" but given that it used to be a paid-for product, I thought I'd highlight that it's now free.