### PR TITLE
Add MQLens to Tools > Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Services:
  - [MongoDB for VS Code](https://marketplace.visualstudio.com/items?itemName=mongodb.mongodb-vscode) - Connect to MongoDB and prototype queries from VS Code
  - [MongoDB MCP Server](https://github.com/mongodb-js/mongodb-mcp-server) - Official Model Context Protocol server for interacting with MongoDB databases and MongoDB Atlas
  - [MongoHub](https://github.com/jeromelebel/MongoHub-Mac) - Mac native client
+ - [MQLens](https://github.com/mqlens/mqlens-mongodb) - Free, native, cross-platform GUI with all auth modes, TLS/SSH/SOCKS5, aggregation explain plans, schema analysis, GridFS, embedded mongosh and an optional AI query assistant; encrypted credentials, zero telemetry
  - [WebDB](https://github.com/WebDB-App/app) – Web-based and open-source "efficient database IDE". Provides ERDs, data generators, an AI assistant, a NoSQL structure manager, a time machine, auto-completion and more
 
 Services:


### PR DESCRIPTION
Adds [MQLens](https://github.com/mqlens/mqlens-mongodb) to **Tools → Desktop** (open-source group, alphabetically after MongoHub).

MQLens is a free, open-source (Apache-2.0), native cross-platform MongoDB GUI built with Tauri (Rust) + React. It covers all auth mechanisms (SCRAM, X.509, MONGODB-AWS, Kerberos, LDAP), TLS/SSH/SOCKS5, aggregation pipelines with explain plans, bulk edit, schema analysis, GridFS, an embedded mongosh, and an optional AI query assistant — with encrypted local credentials and zero telemetry.

- Single entry, placed in alphabetical order.
- Format matches the existing `- [Name](link) - Description` style; description does not repeat the name.