### PR TITLE
Add Velt Sample Apps to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Those open-source applications have MongoDB somewhere in their stack:
  - [Reaction](https://github.com/reactioncommerce/reaction) - Event-driven, real-time commerce platform built with ES6
  - [SaaS Boilerplate](https://github.com/async-labs/saas) - Boilerplate for SaaS products, built with TypeScript, React and Express
  - [uptime](https://github.com/fzaninotto/uptime) - Remote monitoring application built with Node.js and Bootstrap
+ - [Velt Sample Apps](https://github.com/velt-js/sample-apps) - Collaboration sample apps (comments, presence, live cursors, CRDT) that self-host their data in MongoDB
  - [WildDuck Mail Server](https://github.com/nodemailer/wildduck) - Scalable high availability email server that uses MongoDB for email storage
 
 ## License


### PR DESCRIPTION
Adds **Velt Sample Apps** to the Applications section (open-source applications that have MongoDB in their stack).

The sample apps include a self-hosting setup where Velt collaboration data (comments, presence, etc.) is stored in **MongoDB**.

- Repo: https://github.com/velt-js/sample-apps
- MongoDB self-hosting demo: https://github.com/velt-js/sample-apps/tree/main/apps/react/self-hosting/dashboard/mongo-db/dashboard-mongo-db-demo

Single entry, placed alphabetically, repo link, format matching the section (`- [Name](repo) - description`).