### PR TITLE
Add DocKit (MongoDB desktop GUI with Data AI Agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Services:
 
 ### Desktop
  - [Compass](https://github.com/mongodb-js/compass) - Free Cross-platform GUI from MongoDB
+ - [DocKit](https://github.com/geek-fun/dockit) - Open-source MongoDB GUI client with built-in Data AI Agent for natural language queries, collection management, and import/export. Cross-platform (Tauri + Vue 3).
  - [MongoDB for VS Code](https://marketplace.visualstudio.com/items?itemName=mongodb.mongodb-vscode) - Connect to MongoDB and prototype queries from VS Code
  - [MongoDB MCP Server](https://github.com/mongodb-js/mongodb-mcp-server) - Official Model Context Protocol server for interacting with MongoDB databases and MongoDB Atlas
  - [MongoHub](https://github.com/jeromelebel/MongoHub-Mac) - Mac native client


### PR DESCRIPTION
## Add DocKit to Desktop section

DocKit is an open-source MongoDB GUI client with a built-in Data AI Agent for natural language queries, collection management, and import/export. Cross-platform desktop app built with Tauri + Vue 3.

- GitHub: https://github.com/geek-fun/dockit
- Website: https://www.geekfun.club/products/dockit/mongodb-gui-client