### PR TITLE
Add Argon to Tools > Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Services:
  - [VisuaLeaf](https://visualeaf.com/) - MongoDB GUI designed for speed, clarity, and effortless data exploration
 
 ### Development
+ - [Argon](https://github.com/argon-lab/argon) - Git-style branching, time travel, and merge; create disposable database sandboxes for tests and AI agents
  - [C# Analyzer](https://github.com/mongodb/mongo-csharp-analyzer) - View the MongoDB Query API equivalents of your builder expressions in Visual Studio
  - [mgodatagen](https://github.com/feliixx/mgodatagen) - Random data generator
  - [migrate-mongo](https://github.com/seppevs/migrate-mongo) - Database migration tool


### PR DESCRIPTION
Adds [Argon](https://github.com/argon-lab/argon), an open-source (MIT) engine that brings Git-style branching, time travel, and merge to MongoDB — instant isolated database branches for tests, CI, and AI-agent sandboxes.

Added alphabetically under **Tools > Development**, in the `[Name](link) - description` format. Single suggestion per the contribution guidelines.