### PR TITLE
Add DBAegis

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing. F
 
 ## Tools
 ### Administration
+ - [DBAegis](https://github.com/ILOGICSOFT/dbaegis-community) - Self-hosted web interface for MongoDB logical backups, schedules, history, controlled restores, and restore-drill evidence
  - [mgob](https://github.com/stefanprodan/mgob) - Full-featured MongoDB dockerized backup agent
  - [mongoctl](https://github.com/mongolab/mongoctl) - Manage MongoDB servers and replica sets using JSON configurations
  - [mongodb-tools](https://github.com/jwilder/mongodb-tools) - Three neat Python scripts to work with collections and indexes


### PR DESCRIPTION
## What changed

Adds DBAegis to the MongoDB administration tools section.

## Why

DBAegis Community is an AGPL-3.0 self-hosted web application with MongoDB logical backup and restore workflows, scheduling, backup history, and controlled restore operations. This places it alongside the existing MongoDB backup tooling in the Administration category.

Maintainer disclosure: ILOGICSOFT maintains DBAegis.

## Validation

- Confirmed the project is not already listed or present in an open pull request.
- Placed the entry alphabetically in the Administration section.
- Used the format required by `CONTRIBUTING.md`.
- Ran `git diff --check` successfully.
