### PR TITLE
Add MangoDesk to Tools / Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Services:
 ### Desktop
  - [Compass](https://github.com/mongodb-js/compass) - Free Cross-platform GUI from MongoDB
  - [DocKit](https://github.com/geek-fun/dockit) - Open-source MongoDB GUI client with built-in Data AI Agent for natural language queries, collection management, and import/export. Cross-platform (Tauri + Vue 3).
+ - [MangoDesk](https://github.com/row2002/mangodesk) - Local web GUI with a drag & drop query builder, mongo-shell syntax in the query bar, explain plans, typed inline editing and JSON/NDJSON/CSV export; Node + Express, no build step, runs via npx
  - [MongoDB for VS Code](https://marketplace.visualstudio.com/items?itemName=mongodb.mongodb-vscode) - Connect to MongoDB and prototype queries from VS Code
  - [MongoDB MCP Server](https://github.com/mongodb-js/mongodb-mcp-server) - Official Model Context Protocol server for interacting with MongoDB databases and MongoDB Atlas
  - [MongoHub](https://github.com/jeromelebel/MongoHub-Mac) - Mac native client


### PR DESCRIPTION
Adds [MangoDesk](https://github.com/row2002/mangodesk), a free MongoDB GUI that runs as a local web app (Node + Express, vanilla-JS frontend, no build step, `npx mangodesk`).

It is the only entry in the Desktop section with a drag & drop visual query builder — AND/OR condition groups with type-aware operators, drag-to-sort and drag-to-projection strips, and a live preview of the filter it produces. Other features: a query bar that accepts mongo-shell syntax (unquoted keys, `ObjectId(...)`, `ISODate(...)`, `/regex/i`), explain plans, per-BSON-type inline editing, and JSON/NDJSON/CSV export with an Excel mode.

MIT licensed.

Guidelines checklist:
- Individual pull request for a single suggestion
- Format `[Resource Name](link) - Short description`
- Name is not repeated in the description
- Added in alphabetical order, after DocKit