### PR TITLE
Add LibreDB Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Services:
 ### Desktop
  - [Compass](https://github.com/mongodb-js/compass) - Free Cross-platform GUI from MongoDB
  - [DocKit](https://github.com/geek-fun/dockit) - Open-source MongoDB GUI client with built-in Data AI Agent for natural language queries, collection management, and import/export. Cross-platform (Tauri + Vue 3).
+ - [LibreDB Studio](https://github.com/libredb/libredb-studio) - Browser-based client with a JSON query editor, collection operations and INFO-based monitoring, self-hosted as a container or Helm chart
  - [MongoDB for VS Code](https://marketplace.visualstudio.com/items?itemName=mongodb.mongodb-vscode) - Connect to MongoDB and prototype queries from VS Code
  - [MongoDB MCP Server](https://github.com/mongodb-js/mongodb-mcp-server) - Official Model Context Protocol server for interacting with MongoDB databases and MongoDB Atlas
  - [MongoHub](https://github.com/jeromelebel/MongoHub-Mac) - Mac native client


### PR DESCRIPTION
Adds LibreDB Studio under Tools / Desktop, in alphabetical order, in the open source block.

- Repo: https://github.com/libredb/libredb-studio
- License: MIT
- Install: `docker run -d -p 3000:3000 ghcr.io/libredb/libredb-studio:latest`

It is web based rather than a desktop app, like WebDB in the same list. MongoDB support covers a JSON query editor, collection operations (find, aggregate, insert, update, delete), and monitoring. Nine other engines share the same interface, which is the point for teams running Mongo next to a relational database.
