### PR TITLE
Add Sutido to Desktop tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Services:
  - [Moon Modeler](https://www.datensen.com/) - Data modeling tool for MongoDB and relational databases
  - [NoSQLBooster](https://nosqlbooster.com) - Feature-rich but easy-to-use cross-platform IDE (formerly MongoBooster)
  - [Studio 3T](https://studio3t.com/) - Cross-platform GUI, stable and powerful (formerly MongoChef and Robo 3T)
+ - [Sutido](https://sutido.com/) - Windows client with a mongo-shell editor that autocompletes from your live schema, SSH tunneling, dual driver reaching servers 3.6 and 4.0, and local snapshots of deleted documents for recovery
  - [TablePlus](https://tableplus.com/) - Native, lightweight GUI on macOS
  - [VisuaLeaf](https://visualeaf.com/) - MongoDB GUI designed for speed, clarity, and effortless data exploration
 


### PR DESCRIPTION
Adds [Sutido](https://sutido.com/) to `Tools > Desktop > Services`, in alphabetical order between Studio 3T and TablePlus.

Sutido is a desktop database client that connects to MongoDB alongside PostgreSQL, SQL Server, Aerospike and ClickHouse from one window. The MongoDB-specific parts that make it worth listing next to the existing entries:

- A mongo-shell editor (variables, loops, helper statements, aggregations) with autocomplete drawn from the live schema - collections, fields, query and update operators, aggregation stages.
- A dual driver setup: the current `mongodb` driver for modern servers plus a pinned 6.x driver for servers 3.6 and 4.0, negotiated per connection, so legacy clusters connect without a second tool.
- Deletes are snapshotted into a local changelog before they run and can be restored document by document; `drop()`, `dropDatabase()` and `runCommand` deletes raise a confirmation instead, since nothing can be journaled for those.
- Abort issues a real `killOp` via `$currentOp` rather than just dropping the client's interest in the result.
- SSH tunnelling with trust-on-first-use host keys and a fingerprint dialog when a key changes.

Closed source, Windows only today. Free tier (3 connections, personal use); paid tiers for unlimited connections and commercial use.

Checked against CONTRIBUTING.md: single suggestion, `[Name](link) - description` format, name not repeated in the description, inserted alphabetically.