### PR TITLE
Add Syncle to Tools > Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Services:
  - [mongo_fdw](https://github.com/EnterpriseDB/mongo_fdw) - PostgreSQL foreign data wrapper
  - [mongo-hadoop](https://github.com/mongodb/mongo-hadoop) - Hadoop connector
  - [Mongolastic](https://github.com/ozlerhakan/mongolastic) - MongoDB to Elasticsearch (and vice-versa) migration tool
+ - [Syncle](https://syncle.dev) - Self-hosted sync with PostgreSQL, MySQL, SQLite or Redis, by backfill, polling or change streams
 
 Services:
  - [Cluster to cluster sync](https://www.mongodb.com/products/cluster-to-cluster-sync) - MongoDB Inc. solution for continuous data sync between separate clusters


### PR DESCRIPTION
Adds [Syncle](https://syncle.dev) to **Tools → Data**, alphabetically after Mongolastic.

It sits alongside the existing entries there — mongo-connector, Mongolastic — but works in both directions and across more engines: MongoDB to and from PostgreSQL, MySQL/MariaDB, SQLite and Redis, in any combination. Rows move as a one-off backfill, on a polling cursor, or in real time from the source's change log, which for a MongoDB source means change streams. Destination collections are created when missing, with types translated across engines, and writes are idempotent upserts so replays and retries do not duplicate documents.

Self-hosted and MIT licensed, installed with one command. Docs at https://syncle.dev/docs, source at https://github.com/osmanahmadxai/SYNCLE.

Follows the contributing guide: single entry, alphabetical within the category, `[Name](link) - description` format, and the name is not repeated in the description.