### PR TITLE
Add 1bench to Tools > Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Services:
  - [WebDB](https://github.com/WebDB-App/app) – Web-based and open-source "efficient database IDE". Provides ERDs, data generators, an AI assistant, a NoSQL structure manager, a time machine, auto-completion and more
 
 Services:
+ - [1bench](https://1bench.dev/mongodb) - Native cross-platform desktop client for MongoDB alongside two dozen other relational, document, key-value, vector, and search engines
  - [DataGrip](https://www.jetbrains.com/datagrip/) - Cross-platform JetBrains' IDE
  - [Mingo](https://mingo.io/) - MongoDB Admin. Intuitive UI. Fast. Reliable
  - [Monghoul](https://www.monghoul.com/) - MongoDB GUI with smart autocomplete, visual aggregation builder, and built-in MCP server


### PR DESCRIPTION
Adds [1bench](https://1bench.dev/mongodb) to Tools > Desktop under Services, in alphabetical order.

It is a native cross-platform desktop client (Mac, Windows, Linux) that connects to MongoDB alongside two dozen other engines, so one window covers the document, relational, key-value, vector and search stores in a stack.

Disclosure: I built it.